### PR TITLE
Store API response data in localstorage

### DIFF
--- a/src/components/hero/index.js
+++ b/src/components/hero/index.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React from 'react';
 
 class Header extends React.Component {
   render() {

--- a/src/index.js
+++ b/src/index.js
@@ -6,9 +6,12 @@ import {
   BrowserRouter,
 } from "react-router-dom";
 
+import { setCacheWithExpiry, getCacheWithExpiry } from './utils/helpers.js'
+
+let covidCache = getCacheWithExpiry( "covid-19-cache" );
+
 // Check for API cache
-if ( localStorage.getItem( "covid-19-cache" ) !== null ) {
-  let covidCache = JSON.parse( localStorage.getItem( "covid-19-cache" ) );
+if ( covidCache !== null ) {
   if ( !! covidCache.covidData && !! covidCache.geoLocationData ) {
     ReactDOM.render(
       <BrowserRouter>
@@ -33,7 +36,8 @@ if ( localStorage.getItem( "covid-19-cache" ) !== null ) {
     } )
     .then( ( geoLocationData ) => geoLocationData.json() )
     .then( geoLocationData => {
-      window.localStorage.setItem( "covid-19-cache", JSON.stringify( { covidData: covidData, geoLocationData: geoLocationData } ) );
+      // Cache the API data for 15 minutes
+      setCacheWithExpiry( "covid-19-cache", JSON.stringify( { covidData: covidData, geoLocationData: geoLocationData } ), 900000 );
       ReactDOM.render(
         <BrowserRouter>
           <App covidData={covidData} geoLocationData={geoLocationData} />

--- a/src/index.js
+++ b/src/index.js
@@ -6,26 +6,40 @@ import {
   BrowserRouter,
 } from "react-router-dom";
 
-// Get all COVID-19 data
-fetch( "https://www.covid19-api.com/country/all?format=json", {
-  "method": "GET",
-  "headers": {
-    "x-rapidapi-host": "covid-19-data.p.rapidapi.com"
-  }
-} )
-.then( ( covidData ) => covidData.json() )
-.then( covidData => {
-  // Get geolocation data for user
-  fetch( "https://ipapi.co/json/", {
-    "method": "GET"
-  } )
-  .then( ( geoLocationData ) => geoLocationData.json() )
-  .then( geoLocationData => {
+// Check for API cache
+if ( localStorage.getItem( "covid-19-cache" ) !== null ) {
+  let covidCache = JSON.parse( localStorage.getItem( "covid-19-cache" ) );
+  if ( !! covidCache.covidData && !! covidCache.geoLocationData ) {
     ReactDOM.render(
       <BrowserRouter>
-        <App covidData={covidData} geoLocationData={geoLocationData} />
+        <App covidData={covidCache.covidData} geoLocationData={covidCache.geoLocationData} />
       </BrowserRouter>,
-     document.getElementById( 'root' )
+     document.getElementById( "root" )
     );
+  }
+} else {
+  // Retreive all COVID-19 data
+  fetch( "https://www.covid19-api.com/country/all?format=json", {
+    "method": "GET",
+    "headers": {
+      "x-rapidapi-host": "covid-19-data.p.rapidapi.com"
+    }
+  } )
+  .then( ( covidData ) => covidData.json() )
+  .then( covidData => {
+    // Get geolocation data for user
+    fetch( "https://ipapi.co/json/", {
+      "method": "GET"
+    } )
+    .then( ( geoLocationData ) => geoLocationData.json() )
+    .then( geoLocationData => {
+      window.localStorage.setItem( "covid-19-cache", JSON.stringify( { covidData: covidData, geoLocationData: geoLocationData } ) );
+      ReactDOM.render(
+        <BrowserRouter>
+          <App covidData={covidData} geoLocationData={geoLocationData} />
+        </BrowserRouter>,
+       document.getElementById( "root" )
+      );
+    } );
   } );
-} );
+}

--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -1,0 +1,47 @@
+/**
+ * Set cache in localstorage with an expiration data.
+ *
+ * @param {string} key   The name of the cache to store.
+ * @param {string} value String value to store.
+ * @param {int}    ttl   Time to live value (ms).
+ */
+export const setCacheWithExpiry = ( key, value, ttl ) => {
+  const now = new Date();
+
+  // `item` is an object which contains the original value
+  // as well as the time when it's supposed to expire
+  const item = {
+    value: value,
+    expiry: now.getTime() + ttl,
+  }
+
+  localStorage.setItem( key, JSON.stringify( item ) );
+}
+
+/**
+ * Retreive localstorage cache.
+ *
+ * If the cache has expired, delete the cache and return null.
+ *
+ * @param {string} key The name of the cache to store.
+ */
+export const getCacheWithExpiry = ( key ) => {
+  const itemStr = localStorage.getItem( key );
+
+  // if the item doesn't exist, return null
+  if ( ! itemStr ) {
+    return null;
+  }
+
+  const item = JSON.parse( itemStr );
+  const now = new Date();
+
+  // compare the expiry time of the item with the current time
+  if ( now.getTime() > item.expiry ) {
+    // If the item is expired, delete the item from storage and return null
+    localStorage.removeItem( key );
+    return null;
+  }
+
+  return JSON.parse( item.value );
+}


### PR DESCRIPTION
### Note
https://github.com/EvanHerman/COVID-app/pull/3 Sould be merged first

____

- Store API response data in localstorage to prevent multiple API requests on page loads.
- Cache the value for 15 minutes.
- On retrieval, if the cache is expired, delete it from localstorage and retrieve new data from the API.